### PR TITLE
throttle wrapped function return value behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,19 @@ Supports attaching to an instance method!
     # they don't share the same throttle!
     assert arr == [1, 1]
 
+By default throttle passes through the return value of the wrapped def if
+it was called, or None if the def was not called. Use
+`return_throttle_result=True` to instead return a `bool`:
+
+.. code:: python
+
+    @throttle(1, return_throttle_result=True)
+    def foo():
+        pass
+
+    assert foo() is True, 'True means "called"'
+    assert foo() is False, 'False means "not called" (throttled)'
+
 
 Timeout
 -------

--- a/README.rst
+++ b/README.rst
@@ -114,8 +114,8 @@ Supports attaching to an instance method!
     # they don't share the same throttle!
     assert arr == [1, 1]
 
-By default throttle passes through the return value of the wrapped def if
-it was called, or None if the def was not called. Use
+By default throttle passes through the return value of the wrapped
+function if it was called, or None if the def was not called. Use
 `return_throttle_result=True` to instead return a `bool`:
 
 .. code:: python

--- a/wraptor/decorators/test/test_throttle.py
+++ b/wraptor/decorators/test/test_throttle.py
@@ -24,6 +24,14 @@ def test_forwards_return_val():
     assert test() is 'foo'
     assert test() is None, 'return None when throttled'
 
+def test_return_throttle_result():
+    @throttle(.1, return_throttle_result=True)
+    def test():
+        return 'foo'
+
+    assert test() is True
+    assert test() is False, 'throttled'
+
 def test_fail_instance_method():
     """ Test that throttle without instance_method creates a globally
         shared throttle instance (shared by all instances of the class)

--- a/wraptor/decorators/test/test_throttle.py
+++ b/wraptor/decorators/test/test_throttle.py
@@ -16,6 +16,14 @@ def test_basic():
 
     assert arr == [1, 1]
 
+def test_forwards_return_val():
+    @throttle(.1)
+    def test():
+        return 'foo'
+
+    assert test() is 'foo'
+    assert test() is None, 'return None when throttled'
+
 def test_fail_instance_method():
     """ Test that throttle without instance_method creates a globally
         shared throttle instance (shared by all instances of the class)

--- a/wraptor/decorators/throttle.py
+++ b/wraptor/decorators/throttle.py
@@ -5,10 +5,11 @@ class throttle(object):
     """ Throttle a function to execute at most 1 time per <seconds> seconds
         The function is executed on the forward edge.
     """
-    def __init__(self, seconds=1, instance_method=False):
+    def __init__(self, seconds=1, instance_method=False, return_throttle_result=False):
         self.throttler = context.throttle(seconds=seconds)
         self.seconds = seconds
         self.instance_method = instance_method
+        self.return_throttle_result = return_throttle_result
 
     def __call__(self, fn):
         if self.instance_method:
@@ -27,5 +28,7 @@ class throttle(object):
         @wraps(fn)
         def wrapped(*args, **kwargs):
             with self.throttler:
-                return fn(*args, **kwargs)
+                result = fn(*args, **kwargs)
+                return self.return_throttle_result or result
+            return False if self.return_throttle_result else None
         return wrapped


### PR DESCRIPTION
Reference https://github.com/carlsverre/wraptor/issues/2

Added some tests and docs for the existing behavior of passing through the return value of the wrapped function or None if it is throttled, as well as a new `return_throttle_result` flag to just return True/False.